### PR TITLE
Fix: Start Quiz button unhides questionset

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -1032,7 +1032,7 @@ H5P.QuestionSet = function (options, contentId, contentData) {
     $('.qs-startbutton', $myDom)
       .click(function () {
         $(this).parents('.intro-page').hide();
-        $('.questionset', $myDom).show();
+        $('.questionset', $myDom).removeClass('hidden');
         _showQuestion(params.initialQuestion);
         event.preventDefault();
       })
@@ -1041,7 +1041,7 @@ H5P.QuestionSet = function (options, contentId, contentData) {
           case 13: // Enter
           case 32: // Space
             $(this).parents('.intro-page').hide();
-            $('.questionset', $myDom).show();
+            $('.questionset', $myDom).removeClass('hidden');
             _showQuestion(params.initialQuestion);
             event.preventDefault();
         }


### PR DESCRIPTION
Addresses #121: 

`.show()` is not adequetly handling unhide event when "Start Quiz" button is clicked: the class .hidden never is removed from .questionset, meaning the questions are never displayed.

Tested on v1.20.11